### PR TITLE
Remove min-width from .pdf-app #mainContainer

### DIFF
--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -133,7 +133,6 @@ html[dir="rtl"] .pdf-app #outerContainer.sidebarOpen #sidebarContainer {
   right: 0;
   bottom: 0;
   left: 0;
-  min-width: 320px;
 }
 
 .pdf-app #sidebarContent {


### PR DESCRIPTION
Hello,

When we have a screen with small width as shown below the `secondaryToolbar` doesn't stay visible

![Before](https://user-images.githubusercontent.com/25239841/111693683-adff2a80-880f-11eb-8881-50fa85c361bc.PNG)

Removing the CSS rule `min-width` from `.pdf-app #mainContainer`  makes `secondaryToolbar` component visible again

![After](https://user-images.githubusercontent.com/25239841/111693682-ad669400-880f-11eb-87af-67e6efb82cde.PNG)

This is useful for mobile users that want to print or download the PDF, for example :)
