### PR TITLE
Feature/file title

### DIFF
--- a/src/components/pdf-viewer.vue
+++ b/src/components/pdf-viewer.vue
@@ -1006,7 +1006,7 @@ export default class PdfViewer extends Vue {
   private title!: boolean;
 
   @Prop({ required: false, type: String })
-  private fileTitle!: string; 
+  private downloadFileName?: string; 
 
   private defaultLocale = JSON.stringify(locale);
 
@@ -1098,11 +1098,16 @@ export default class PdfViewer extends Vue {
       pdfApp.PDFViewerApplication.close();
     } else {
       pdfApp.PDFViewerApplication.open(this.pdf)
-        .then(this.openDocument.bind(this))
+        .then(() => {
+          return pdfApp.PDFViewerApplication.pdfDocument.getMetadata();
+        })
+        .then((fileMetadata: any) => {
+          pdfApp.PDFViewerApplication.contentDispositionFilename = this.downloadFileName || fileMetadata.contentDispositionFilename
+        })
+        .then(() => {
+          return this.openDocument();
+        })
         .catch(errorHandler);
-      if (this.fileTitle) {
-        pdfApp.PDFViewerApplication.setTitleUsingUrl(this.fileTitle)
-      }
     }
   }
 

--- a/src/components/pdf-viewer.vue
+++ b/src/components/pdf-viewer.vue
@@ -1005,6 +1005,9 @@ export default class PdfViewer extends Vue {
   @Prop({ required: false, type: Boolean, default: () => false })
   private title!: boolean;
 
+  @Prop({ required: false, type: String })
+  private fileTitle!: string; 
+
   private defaultLocale = JSON.stringify(locale);
 
   private isOpenHandlerBinded = false;
@@ -1097,6 +1100,9 @@ export default class PdfViewer extends Vue {
       pdfApp.PDFViewerApplication.open(this.pdf)
         .then(this.openDocument.bind(this))
         .catch(errorHandler);
+      if (this.fileTitle) {
+        pdfApp.PDFViewerApplication.setTitleUsingUrl(this.fileTitle)
+      }
     }
   }
 

--- a/src/components/pdf-viewer.vue
+++ b/src/components/pdf-viewer.vue
@@ -1006,7 +1006,7 @@ export default class PdfViewer extends Vue {
   private title!: boolean;
 
   @Prop({ required: false, type: String })
-  private downloadFileName?: string; 
+  private fileName?: string; 
 
   private defaultLocale = JSON.stringify(locale);
 
@@ -1102,7 +1102,7 @@ export default class PdfViewer extends Vue {
           return pdfApp.PDFViewerApplication.pdfDocument.getMetadata();
         })
         .then((fileMetadata: any) => {
-          pdfApp.PDFViewerApplication.contentDispositionFilename = this.downloadFileName || fileMetadata.contentDispositionFilename
+          pdfApp.PDFViewerApplication.contentDispositionFilename = this.fileName || fileMetadata.contentDispositionFilename
         })
         .then(() => {
           return this.openDocument();

--- a/src/views/pdf-app.vue
+++ b/src/views/pdf-app.vue
@@ -2,6 +2,7 @@
   <pdf-viewer
     :pdf="pdf"
     :config="config"
+    downloadFileName="test"
     @after-created="afterCreated"
     @open="open"
     @pages-rendered="pagesRendered"

--- a/src/views/pdf-app.vue
+++ b/src/views/pdf-app.vue
@@ -2,7 +2,7 @@
   <pdf-viewer
     :pdf="pdf"
     :config="config"
-    downloadFileName="test"
+    fileName="Custom fileName"
     @after-created="afterCreated"
     @open="open"
     @pages-rendered="pagesRendered"


### PR DESCRIPTION
In my application I had the need to set custom filenames for the documents, otherwise all documents loaded by vue-pdf-app would be downloaded as `document.pdf`.  I could solve this issue in my app by simply calling the following function in the `openHandler`:

`PDFViewerApplication.setTitleUsingUrl(this.titttle)`

Perhaps this could be an interesting feature for the community, therefore I introduced in this pull request a new property, called `fileTitle`.